### PR TITLE
Fix reply text field not gaining focus on selection

### DIFF
--- a/plugins/Ubuntu/Settings/Components/ActionTextField.qml
+++ b/plugins/Ubuntu/Settings/Components/ActionTextField.qml
@@ -28,6 +28,7 @@ Item {
     property alias buttonText: sendButton.text
     property bool activateEnabled: false
     property alias textHint: replyField.placeholderText
+    property alias textFieldFocused: replyField.focus
 
     signal activated(var value)
 
@@ -42,14 +43,6 @@ Item {
             id: replyField
             objectName: "replyText"
             autoSize: true
-
-            onEnabledChanged: {
-                //Make sure that the component lost focus when enabled = false,
-                //otherwise it will get focus again when enable = true
-                if (!enabled) {
-                    focus = false;
-                }
-            }
         }
 
         Button {

--- a/plugins/Ubuntu/Settings/Menus/TextMessageMenu.qml
+++ b/plugins/Ubuntu/Settings/Menus/TextMessageMenu.qml
@@ -36,6 +36,7 @@ SimpleMessageMenu {
         id: actionTextField
         activateEnabled: true
         buttonText: i18n.dtr("ubuntu-settings-components", "Send")
+        textFieldFocused: enabled ? menu.selected : false
 
         onActivated: {
             menu.replied(value);


### PR DESCRIPTION
We use the selected & enabled state of the listitem to determine
the focused state of the textfield.

Fixes https://github.com/ubports/ubuntu-touch/issues/607