### PR TITLE
Work around the pt_PT workaround

### DIFF
--- a/plugins/Ubuntu/Settings/Components/Calendar.qml
+++ b/plugins/Ubuntu/Settings/Components/Calendar.qml
@@ -291,8 +291,9 @@ Component {
                 model: priv.days
 
                 delegate: Label {
+                    readonly property string localeName : Qt.locale().name === "pt_PT" ? "pt" : Qt.locale().name // https://github.com/ubports/ubuntu-touch/issues/510
                     objectName: "weekDay" + index
-                    text: Qt.locale(i18n.language).standaloneDayName((index + firstDayOfWeek) % priv.days, Locale.ShortFormat).toUpperCase()
+                    text: Qt.locale(localeName).standaloneDayName((index + firstDayOfWeek) % priv.days, Locale.ShortFormat).toUpperCase()
                     textSize: Label.XSmall
                     // FIXME: There's no good palette that covers both
                     //        Ambiance (Ash) and Suru (Silk)


### PR DESCRIPTION
This is a workaround for https://github.com/ubports/ubuntu-touch/issues/510. It fixes the issue for the datetime indicator and any other app that uses this Calendar type by using a "more correct" locale than pt_PT for the short standaloneDayNames.