### PR TITLE
Fix crashing when reloading CalendarMenu quickly

### DIFF
--- a/SettingsComponents/TimeZone/TimeZone.qml
+++ b/SettingsComponents/TimeZone/TimeZone.qml
@@ -16,8 +16,8 @@
  * Authored by Andrea Cimitan <andrea.cimitan@canonical.com>
  */
 
-import QtQuick 2.0
-import Ubuntu.Components 0.1
+import QtQuick 2.4
+import Ubuntu.Components 1.3
 import "Time.js" as TimeLocal
 
 Item {

--- a/plugins/Ubuntu/Settings/Menus/CalendarMenu.qml
+++ b/plugins/Ubuntu/Settings/Menus/CalendarMenu.qml
@@ -103,18 +103,13 @@ BaseMenu {
             objectName: "calenderMenuSlotsLayout"
             style: menuStyle
 
-            mainSlot: Item {
-                // XXX: this extra Item seems to be needed by Qt 5.4,
-                //      we can remove it once migrated to new versions
-                height: calendar.height
-                Calendar {
-                    id: calendar
-                    objectName: "calendar"
-                    interactive: !pointerMode
-                    anchors {
-                        left: parent.left
-                        right: parent.right
-                    }
+            mainSlot: Calendar {
+                id: calendar
+                objectName: "calendar"
+                interactive: !pointerMode
+                anchors {
+                    left: parent.left
+                    right: parent.right
                 }
             }
         }


### PR DESCRIPTION
Prior to this change, Lomiri (Unity8) would occasionally segfault in QQuickListViewPrivate::layoutVisibleItems when loading the datetime indicator on startup.

After this change, I was able to restart Lomiri 70 times in a row without a crash occurring. Without this change, it won't usually go more than 5 restarts without crashing.

Don't worry, I didn't restart it manually.

I'm not quite sure why this fixes the issue.