### PR TITLE
Moved delete VPN icon from List to the left

### DIFF
--- a/plugins/Ubuntu/Settings/Vpn/VpnList.qml
+++ b/plugins/Ubuntu/Settings/Vpn/VpnList.qml
@@ -55,7 +55,7 @@ ListView {
 
         divider.visible: true
 
-        trailingActions: ListItemActions {
+        leadingActions: ListItemActions {
            actions: [
                Action {
                    iconName: "delete"


### PR DESCRIPTION
Fixes #7 

Before:
![imatge](https://user-images.githubusercontent.com/6640041/79698200-a2198a00-8287-11ea-8b18-32100c56b19a.png)

After:
![imatge](https://user-images.githubusercontent.com/6640041/79698211-bb223b00-8287-11ea-8c9b-e6e2fc4b42ec.png)

Aesthetic change :)