### PR TITLE
Clip ListView for the AdaptivePageLayout View

### DIFF
--- a/plugins/Ubuntu/Settings/Vpn/VpnList.qml
+++ b/plugins/Ubuntu/Settings/Vpn/VpnList.qml
@@ -32,6 +32,7 @@ ListView {
     }
 
     height: contentItem.height
+    clip: true
 
     delegate: ListItem {
         objectName: "vpnListConnection" + index


### PR DESCRIPTION
Fixes: #10 

On tablets, the ListView is not clipped:

Before:
![imatge](https://user-images.githubusercontent.com/6640041/80148215-00f74000-85b5-11ea-949a-73e9ffc1ae87.png)

After:
![imatge](https://user-images.githubusercontent.com/6640041/80148249-0bb1d500-85b5-11ea-94c7-6de70b2cec47.png)
