### PR TITLE
Update pot file

### DIFF
--- a/po/ubuntu-settings-components.pot
+++ b/po/ubuntu-settings-components.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ubuntu-settings-components\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-18 15:20+0000\n"
+"POT-Creation-Date: 2020-04-23 22:59+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -148,7 +148,7 @@ msgstr ""
 msgid "Send"
 msgstr ""
 
-#: plugins/Ubuntu/Settings/Vpn/DialogFile.qml:170
+#: plugins/Ubuntu/Settings/Vpn/DialogFile.qml:169
 msgid "Accept"
 msgstr ""
 
@@ -470,7 +470,7 @@ msgstr ""
 msgid "VPN"
 msgstr ""
 
-#: plugins/Ubuntu/Settings/Vpn/VpnPreviewDialog.qml:96
+#: plugins/Ubuntu/Settings/Vpn/VpnPreviewDialog.qml:95
 msgid "Change"
 msgstr ""
 


### PR DESCRIPTION
Updated translations pot file

Output from command line was:
```
$ ./update-usc-pot 
./plugins/Ubuntu/Settings/Fingerprint/CircularSegment.qml:35: avís: el literal cadena no està terminat
./plugins/Ubuntu/Settings/Fingerprint/CircularSegment.qml:62: avís: el literal cadena no està terminat
./plugins/Ubuntu/Settings/Fingerprint/SegmentRenderer.qml:47: avís: el literal cadena no està terminat
./plugins/Ubuntu/Settings/Fingerprint/SegmentRenderer.qml:63: avís: el literal cadena no està terminat
update-usc-pot: /[...]/settings-components/po/ubuntu-settings-components.pot updated
```
I assume that is because of the format of the file [CS line 35](https://github.com/ubports/settings-components/blob/master/plugins/Ubuntu/Settings/Fingerprint/CircularSegment.qml#L35), [CS line 62](https://github.com/ubports/settings-components/blob/master/plugins/Ubuntu/Settings/Fingerprint/CircularSegment.qml#L62), [SR line 47](https://github.com/ubports/settings-components/blob/master/plugins/Ubuntu/Settings/Fingerprint/SegmentRenderer.qml#L47) and [63](https://github.com/ubports/settings-components/blob/master/plugins/Ubuntu/Settings/Fingerprint/SegmentRenderer.qml#L63)